### PR TITLE
Fix case where registry is saved while empty.

### DIFF
--- a/Products/ResourceRegistries/tools/JSRegistry.py
+++ b/Products/ResourceRegistries/tools/JSRegistry.py
@@ -156,7 +156,7 @@ class JSRegistryTool(BaseRegistryTool):
         """
         debugmode = REQUEST.get('debugmode', False)
         self.setDebugMode(debugmode)
-        records = REQUEST.form.get('scripts')
+        records = REQUEST.form.get('scripts', [])
         records.sort(lambda a, b: a.sort-b.sort)
         self.resources = ()
         scripts = []


### PR DESCRIPTION
Currently errors on the line below when trying to sort None.
