### PR TITLE
Adds support for OFS.Image.File-objects using OFS.Image.Pdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .*
-*.egg-info
-*.pyc
+*.py?
+Products.ResourceRegistries.egg-info/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,47 @@
 Changelog
 =========
 
+2.1.1 (unreleased)
+------------------
 
-2.0.7 (unreleased)
+- Nothing changed yet.
+
+
+2.1 (2012-04-18)
+----------------
+
+- Use iterative magic number generation based on the properties of all
+  included resources (for each concatenated resource).
+
+  This fixes an issue with external caches where resources for
+  different content would sometimes get assigned the same resource id
+  (due to the previous implementation using a random integer), making
+  it impossible to cache a resource correctly without additional
+  information.
+  [malthe]
+
+
+2.1a1 (2011-06-28)
+------------------
+
+- Add bundle concept - a bundle is a string tag against a resource, which can
+  be used to filter resources by theme. Each theme has a list of enabled
+  bundles, managed on the 'Bundles' tab in the ZMI (note that this is global).
+  [optilude]
+
+- Fix handling of the purge attribute on import.
+  [rossp]
+
+
+2.0.8 (2012-03-14)
+------------------
+
+- Add time element. This is necessary for the generated ids to update
+  on any save, to reflect possible updates in the served content.
+  [malthe]
+
+
+2.0.7 (2012-03-14)
 ------------------
 
 - Added support for OFS.Image.File-objects using OFS.Image.PData
@@ -100,7 +139,7 @@ Changelog
   the various constructor methods, or as an attribute in a cssregistry.xml
   file. It defaults to false. It has no effect in debug mode. In non-debug-
   mode, however, it will parse a stylesheet for 'url()' statements that
-  container *relative- paths. These will be prefixed with the Plone site path.
+  contain *relative* paths. These will be prefixed with the Plone site path.
   If the stylesheet id contains a path (e.g. '++resource++foo/css/bar.css')
   this will be used in the prefix as well. The goal is to make relative paths
   internal to a resource directory work, even when resource merging is used.

--- a/Products/ResourceRegistries/configure.zcml
+++ b/Products/ResourceRegistries/configure.zcml
@@ -6,5 +6,17 @@
   <five:registerPackage
       package="."
       initialize=".initialize" />
+      
+  <adapter
+      for=".interfaces.IResourceRegistry"
+      name="persistent"
+      factory=".tools.BaseRegistry.PersistentResourceProvider"
+      />
+      
+  <subscriber
+        for=".interfaces.settings.IResourceRegistriesSettings
+              plone.registry.interfaces.IRecordModifiedEvent"
+        handler=".tools.BaseRegistry.cookWhenChangingSettings"
+        />
 
 </configure>

--- a/Products/ResourceRegistries/exportimport/resourceregistry.py
+++ b/Products/ResourceRegistries/exportimport/resourceregistry.py
@@ -96,7 +96,7 @@ class ResourceRegistryNodeAdapter(XMLAdapterBase):
         reg_method = getattr(registry, self.register_method)
         unreg_method = getattr(registry, self.unregister_method)
         update_method = getattr(registry, self.update_method)
-        if node.attributes.get('purge', '') == 'true':
+        if getattr(node.attributes.get('purge'), 'value', '') == 'true':
             registry.clearResources()
         for child in node.childNodes:
             if child.nodeName != self.resource_type:

--- a/Products/ResourceRegistries/interfaces/__init__.py
+++ b/Products/ResourceRegistries/interfaces/__init__.py
@@ -1,2 +1,3 @@
-from registries import IResourceRegistry, ICSSRegistry, IKSSRegistry, IJSRegistry, ICookedFile
-from viewletmanagers import IHtmlHeadScripts, IHtmlHeadStyles
+from Products.ResourceRegistries.interfaces.registries import IResourceRegistry, ICSSRegistry, IKSSRegistry, IJSRegistry, ICookedFile, IResourceProvider
+from Products.ResourceRegistries.interfaces.viewletmanagers import IHtmlHeadScripts, IHtmlHeadStyles
+from Products.ResourceRegistries.interfaces.settings import IResourceRegistriesSettings

--- a/Products/ResourceRegistries/interfaces/registries.py
+++ b/Products/ResourceRegistries/interfaces/registries.py
@@ -6,6 +6,18 @@ class ICookedFile(Interface):
     concatenated resources.
     """
 
+class IResourceProvider(Interface):
+    """A provider of resources.
+    
+    Register a named adapter from the particular resource registry object
+    to this interface to provide resources from locations other than the
+    main persistent registry.
+    """
+    
+    def getResources(self):
+        """Get a list of available Resource objects
+        """
+
 class IResourceRegistry(Interface):
     """A tool for registering and evaluating resource linkage."""
 

--- a/Products/ResourceRegistries/interfaces/settings.py
+++ b/Products/ResourceRegistries/interfaces/settings.py
@@ -1,0 +1,16 @@
+from zope.interface import Interface
+from zope import schema
+from zope.i18nmessageid import MessageFactory
+
+_ = MessageFactory('plone')
+
+class IResourceRegistriesSettings(Interface):
+    """Settings stored in portal_registry
+    """
+    
+    resourceBundlesForThemes = schema.Dict(
+            title=_(u"Resource bundles for themes"),
+            description=_(u"Maps skin names to lists of resource bundle names"),
+            key_type=schema.ASCIILine(),
+            value_type=schema.List(value_type=schema.ASCIILine())
+        )

--- a/Products/ResourceRegistries/tests/testBaseRegistry.py
+++ b/Products/ResourceRegistries/tests/testBaseRegistry.py
@@ -1,4 +1,5 @@
 import unittest
+
 from Products.ResourceRegistries.tools.BaseRegistry import BaseRegistryTool, Resource
 
 class BaseRegistryTestCase(unittest.TestCase):
@@ -9,8 +10,10 @@ class BaseRegistryTestCase(unittest.TestCase):
     # Make sure we don't generate an id that could screw up traversal to
     # the cached resource.
     def testGenerateId(self):
-        self.failIf('++' in self.registry.generateId('++resource++foobar.css'))
-        self.failIf('/' in self.registry.generateId('++resource++foo/bar.css'))
+        self.failIf('++' in self.registry.generateId(
+            Resource('++resource++foobar.css')))
+        self.failIf('/' in self.registry.generateId(
+            Resource('++resource++foo/bar.css')))
     
     #Resources with double //'s in them aren't traversable. The page templates
     # assume that no resource will have a '/' at the start or end, and won't
@@ -25,7 +28,7 @@ class BaseRegistryTestCase(unittest.TestCase):
                }
         for id in ids:
             if ids[id]: #This shouldn't error
-                res = Resource(id)
+                Resource(id)
             else: #This should throw a ValueError
                 self.failUnlessRaises(ValueError,Resource,id)
                 self.assertRaises(ValueError,Resource,id)
@@ -34,11 +37,9 @@ class BaseRegistryTestCase(unittest.TestCase):
         self.testGenerateId()
         self.testTraversableResourceID()
 
+
+
 def test_suite():
     suite = unittest.TestSuite()
-
     suite.addTest(BaseRegistryTestCase())
-
     return suite
-
-

--- a/Products/ResourceRegistries/tests/testJSRegistry.py
+++ b/Products/ResourceRegistries/tests/testJSRegistry.py
@@ -1023,6 +1023,74 @@ class TestCachingHeaders(FunctionalRegistryTestCase):
         self.assertEqual(response.getHeader('Expires'), rfc1123_date(soon.timeTime()))
         self.assertEqual(response.getHeader('Cache-Control'), 'max-age=%d' % int(days*24*3600))
 
+class TestBundling(RegistryTestCase):
+
+    def afterSetUp(self):
+        self.tool = getattr(self.portal, JSTOOLNAME)
+        self.tool.clearResources()
+        
+        # Fake install of portal_registry tool
+        from Products.ResourceRegistries.interfaces.settings import IResourceRegistriesSettings
+        from plone.registry.interfaces import IRegistry
+        from zope.component import getUtility
+        
+        self.portal['portal_skins'].addSkinSelection('alpha', 'pink,ResourceRegistries')
+        self.portal['portal_skins'].addSkinSelection('beta', 'purple,ResourceRegistries')
+        self.portal['portal_skins'].addSkinSelection('delta', 'yellow,ResourceRegistries')
+        
+        self.registry = getUtility(IRegistry)
+        self.registry.registerInterface(IResourceRegistriesSettings)
+
+    def test_getBundlesForThemes_default(self):
+        bundlesForThemes = self.tool.getBundlesForThemes()
+        for theme in self.portal['portal_skins'].getSkinSelections():
+            self.assertEqual(bundlesForThemes[theme], ['default'])
+            self.assertEqual(self.tool.getBundlesForTheme(theme), ['default'])
+    
+    def test_getBundlesForTheme_fallback(self):
+        self.assertEqual(self.tool.getBundlesForTheme('invalid-theme'), ['default'])
+
+    def test_manage_saveBundlesForThemes(self):
+        self.tool.manage_saveBundlesForThemes({
+                'alpha': ['default', 'foobar'],
+                'beta': [],
+            })
+        
+        self.assertEqual(self.tool.getBundlesForTheme('alpha'), ['default', 'foobar'])
+        self.assertEqual(self.tool.getBundlesForTheme('beta'), [])
+        self.assertEqual(self.tool.getBundlesForTheme('invalid-theme'), ['default'])
+
+    def test_getCookedResourcesByTheme(self):
+        self.tool.registerScript('ham', bundle='default')
+        self.tool.registerScript('spam', bundle='foo')
+        self.tool.registerScript('eggs') # will be in the 'default' bundle
+        
+        self.tool.manage_saveBundlesForThemes({
+                'alpha': ['default', 'foo'],
+                'beta': ['foo'],
+                'delta': ['default'],
+            })
+        
+        merged = self.tool.getCookedResources('alpha')
+        self.assertEqual(len(merged), 1)
+        components = self.tool.concatenatedResourcesByTheme['alpha'][merged[0].getId()]
+        self.assertEqual(components, ['ham', 'spam', 'eggs'])
+        
+        merged = self.tool.getCookedResources('beta')
+        self.assertEqual(len(merged), 1)
+        components = self.tool.concatenatedResourcesByTheme['beta'][merged[0].getId()]
+        self.assertEqual(components, ['spam'])
+        
+        merged = self.tool.getCookedResources('delta')
+        self.assertEqual(len(merged), 1)
+        components = self.tool.concatenatedResourcesByTheme['delta'][merged[0].getId()]
+        self.assertEqual(components, ['ham', 'eggs'])
+        
+        current = self.portal['portal_skins'].getCurrentSkinName()
+        merged = self.tool.getCookedResources(current)
+        self.assertEqual(len(merged), 1)
+        components = self.tool.concatenatedResourcesByTheme[current][merged[0].getId()]
+        self.assertEqual(components, ['ham', 'eggs'])
 
 class TestPdataAwareness(FunctionalRegistryTestCase):
 
@@ -1070,6 +1138,6 @@ def test_suite():
     suite.addTest(makeSuite(TestResourcePermissions))
     suite.addTest(makeSuite(TestUnicodeAwareness))
     suite.addTest(makeSuite(TestCachingHeaders))
+    suite.addTest(makeSuite(TestBundling))
     suite.addTest(makeSuite(TestPdataAwareness))
-
     return suite

--- a/Products/ResourceRegistries/tools/BaseRegistry.py
+++ b/Products/ResourceRegistries/tools/BaseRegistry.py
@@ -1,11 +1,18 @@
-import random
+import logging
 
 # we *have* to use StringIO here, because we can't add attributes to cStringIO
 # instances (needed in BaseRegistryTool.__getitem__).
 from StringIO import StringIO
 from urllib import quote_plus
+from md5 import md5
+from time import time
 
 from zope.interface import implements, alsoProvides
+from zope.component import getAdapters
+from zope.component import queryUtility
+from zope.site.hooks import getSite
+
+from plone.registry.interfaces import IRegistry
 
 from AccessControl import ClassSecurityInfo, Unauthorized
 from AccessControl.SecurityManagement import getSecurityManager
@@ -27,11 +34,19 @@ from Products.CMFCore.Expression import createExprContext
 from Products.CMFCore.utils import UniqueObject, getToolByName
 from Products.Five.browser.resource import Resource as z3_Resource
 
+from Products.PageTemplates.PageTemplateFile import PageTemplateFile
+
 from Products.ResourceRegistries import permissions
+from Products.ResourceRegistries import config
+
 from Products.ResourceRegistries.interfaces import IResourceRegistry
 from Products.ResourceRegistries.interfaces import ICookedFile
+from Products.ResourceRegistries.interfaces import IResourceProvider
+from Products.ResourceRegistries.interfaces.settings import IResourceRegistriesSettings
 
 DEVEL_MODE = dict()
+
+LOGGER = logging.getLogger('ResourceRegistries')
 
 def getDummyFileForContent(name, ctype):
     # make output file like and add an headers dict, so the contenttype
@@ -56,6 +71,24 @@ def is_anonymous():
     user = getSecurityManager().getUser()
     return bool(user.getUserName() == 'Anonymous User')
 
+class PersistentResourceProvider(object):
+    implements(IResourceProvider)
+    
+    def __init__(self, context):
+        self.context = context
+    
+    def getResources(self):
+        """Get a list of available Resource objects
+        """
+        return self.context.resources
+
+def cookWhenChangingSettings(settings, event):
+    """When our settings are changed, re-cook the main registries
+    """
+    for name in (config.JSTOOLNAME, config.CSSTOOLNAME, config.KSSTOOLNAME,):
+        tool = getToolByName(getSite(), name, None)
+        if tool is not None:
+            tool.cookResources()
 
 class Resource(Persistent):
     security = ClassSecurityInfo()
@@ -73,6 +106,7 @@ class Resource(Persistent):
         self._data['cookable'] = kwargs.get('cookable', True)
         self._data['cacheable'] = kwargs.get('cacheable', True)
         self._data['conditionalcomment'] = kwargs.get('conditionalcomment','')
+        self._data['bundle'] = kwargs.get('bundle', 'default')
         self.isExternal = extres
         if extres:
             self._data['cacheable'] = False #External resources are NOT cacheable
@@ -172,14 +206,23 @@ class Resource(Persistent):
     def isExternalResource(self):
         return getattr(self, 'isExternal', False)
 
+    security.declarePublic('getBundle')
+    def getBundle(self):
+        return self._data.get('bundle', None) or 'default'
+    
+    security.declareProtected(permissions.ManagePortal, 'setBundle')
+    def setBundle(self, bundle):
+        self._data['bundle'] = bundle
+
 InitializeClass(Resource)
 
 
 class Skin(Acquisition.Implicit):
     security = ClassSecurityInfo()
 
-    def __init__(self, skin):
+    def __init__(self, skin, resources):
         self._skin = skin
+        self.resources = resources
 
     def __before_publishing_traverse__(self, object, REQUEST):
         """ Pre-traversal hook. Specify the skin. 
@@ -188,8 +231,7 @@ class Skin(Acquisition.Implicit):
 
     def __bobo_traverse__(self, REQUEST, name):
         """Traversal hook."""
-        if REQUEST is not None and \
-           self.concatenatedresources.get(name, None) is not None:
+        if REQUEST is not None and self.resources.get(name, None) is not None:
             parent = aq_parent(self)
             # see BaseTool.__bobo_traverse__
             deferred = getDummyFileForContent(name, self.getContentType())
@@ -206,13 +248,22 @@ class Skin(Acquisition.Implicit):
 
 InitializeClass(Skin)
 
+_marker = {} # must be a dict
 
 class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
     """Base class for a Plone registry managing resource files."""
 
     security = ClassSecurityInfo()
     implements(IResourceRegistry)
-    manage_options = SimpleItem.manage_options
+    
+    manage_bundlesForm = PageTemplateFile('www/bundles', config.GLOBALS)
+    
+    manage_options = (
+        {
+            'label': 'Bundles',
+            'action': 'manage_bundlesForm',
+        },
+    ) + SimpleItem.manage_options
 
     attributes_to_compare = ('getAuthenticated', 'getExpression',
                              'getCookable', 'getCacheable',
@@ -223,6 +274,10 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
     cache_duration = 3600
     resource_class = Resource
 
+    # Kept here for BBB to avoid need to migrate these in
+    cookedResourcesByTheme = _marker
+    concatenatedResourcesByTheme = _marker
+    
     #
     # Private Methods
     #
@@ -230,8 +285,32 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
     def __init__(self):
         """Add the storages."""
         self.resources = ()
-        self.cookedresources = ()
-        self.concatenatedresources = {}
+
+        self.cookedResourcesByTheme = {} # theme -> tuple of cooked resources
+        self.concatenatedResourcesByTheme = {} # theme -> {magic (public) id -> list of actual resource ids}
+    
+    # Get/set cooked resources and concatenated resources for the current
+    # theme. This is mainly BBB support.
+    
+    @property
+    def cookedresources(self):
+        if 'cookedresources' in self.__dict__:
+            self._migrateCookedResouces()
+        theme = self.getCurrentSkinName()
+        return self.cookedResourcesByTheme.get(theme, ())
+
+    @property
+    def concatenatedresources(self):
+        if 'concatenatedresources' in self.__dict__:
+            self._migrateCookedResouces()
+        theme = self.getCurrentSkinName()
+        return self.concatenatedResourcesByTheme.get(theme, {})
+
+    def _migrateCookedResouces(self):
+        LOGGER.warn("Migrating old concatenated resources storage on the fly - this should only happen once per tool")
+        self.cookResources()
+        del self.__dict__['cookedresources']
+        del self.__dict__['concatenatedresources']
 
     def __getitem__(self, item):
         """Return a resource from the registry."""
@@ -298,10 +377,12 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         skintool = getToolByName(self, 'portal_skins')
         skins = skintool.getSkinSelections()
         if name in skins:
-            return Skin(name).__of__(self)
-
+            return Skin(name, self.concatenatedResourcesByTheme.get(name, {})).__of__(self)
+        
+        theme = self.getCurrentSkinName()
+        
         if REQUEST is not None and \
-           self.concatenatedresources.get(name, None) is not None:
+                self.concatenatedResourcesByTheme.get(theme, {}).get(name, None) is not None:
             # __bobo_traverse__ is called before the authentication has
             # taken place, so if some operations require an authenticated
             # user (like restrictedTraverse in __getitem__) it will fail.
@@ -326,9 +407,13 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         raise AttributeError('%s' % (name,))
 
     security.declarePublic('isCacheable')
-    def isCacheable(self, name):
+    def isCacheable(self, name, theme=None):
         """Return a boolean whether the resource is cacheable or not."""
-        resource_id = self.concatenatedresources.get(name, [None])[0]
+        
+        if theme is None:
+            theme = self.getCurrentSkinName()
+        
+        resource_id = self.concatenatedResourcesByTheme.get(theme, {}).get(name, [None])[0]
         if resource_id is None:
             return False
         resources = self.getResourcesDict()
@@ -346,7 +431,7 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
     security.declarePrivate('storeResource')
     def storeResource(self, resource, skipCooking=False):
         """Store a resource."""
-        self.validateId(resource.getId(), self.getResources())
+        self.validateId(resource.getId(), self.resources)
         resources = list(self.resources)
         resources.append(resource)
         self.resources = tuple(resources)
@@ -360,8 +445,8 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         Convenience funtion for Plone migrations and tests.
         """
         self.resources = ()
-        self.cookedresources = ()
-        self.concatenatedresources = {}
+        self.cookedResourcesByTheme = {}
+        self.concatenatedResourcesByTheme = {}
 
     security.declarePrivate('getResourcesDict')
     def getResourcesDict(self):
@@ -392,17 +477,26 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
                 self.attributes_to_compare]
 
     security.declarePrivate('generateId')
-    def generateId(self, res_id, prev_id=None):
+    def generateId(self, resource, other=None):
         """Generate a random id."""
-        id_parts = res_id.split('.')
-        if (len(id_parts) > 1):
-            base = '.'.join(id_parts[:-1])
-            appendix = ".%s" % id_parts[-1]
+
+        res_id = resource.getId()
+
+        if other is not None:
+            other_id = other.getId()
+            key = md5(other_id)
+            key.update(res_id)
+            base = res_id.rsplit('-')[0]
+            key = "%s-" % (base, key.hexdigest())
+            ext = "." + res_id.rsplit('.', 1)[1]
         else:
-            base = id_parts[0]
-            appendix = self.filename_appendix
-        base = base.replace('++', '').replace('/', '')
-        return '%s-cachekey%04d%s' % (base, random.randint(0, 9999), appendix)
+            base = res_id.replace('++', '').replace('/', '').rsplit('.', 1)[0]
+            key = md5(res_id)
+            key.update(str(int(time() * 1000)))
+            key = "%s-cachekey-%s" % (base, key.hexdigest())
+            ext = self.filename_appendix
+
+        return key + ext
 
     security.declarePrivate('finalizeResourceMerging')
     def finalizeResourceMerging(self, resource, previtem):
@@ -425,41 +519,70 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         """Cook the stored resources."""
         if self.ZCacheable_isCachingEnabled():
             self.ZCacheable_invalidate()
-        resources = [r.copy() for r in self.getResources() if r.getEnabled()]
-        self.concatenatedresources = {}
-        self.cookedresources = ()
-        results = []
-        for resource in resources:
-            if results:
-                previtem = results[-1]
-                if resource.getCookable() and previtem.getCookable() \
-                       and self.compareResources(resource, previtem):
-                    res_id = resource.getId()
-                    prev_id = previtem.getId()
-                    self.finalizeResourceMerging(resource, previtem)
-                    if self.concatenatedresources.has_key(prev_id):
-                        self.concatenatedresources[prev_id].append(res_id)
+        
+        self.concatenatedResourcesByTheme = {}
+        self.cookedResourcesByTheme = {}
+        
+        bundlesForThemes = self.getBundlesForThemes()
+        for theme, bundles in bundlesForThemes.items():
+            
+            resources = [r.copy() for r in self.getResources() if r.getEnabled()]
+            results = []
+            
+            concatenatedResources = self.concatenatedResourcesByTheme[theme] = {}
+            
+            for resource in resources:
+                
+                # Skip resources in bundles not in this theme. None bundles
+                # are assumed to 
+                
+                bundle = resource.getBundle()
+                if bundle not in bundles:
+                    continue
+                
+                if results:
+                    previtem = results[-1]
+                
+                    # Is this resource compatible the previous one we used?
+                    if resource.getCookable() and previtem.getCookable() \
+                           and self.compareResources(resource, previtem):
+                        res_id = resource.getId()
+                        prev_id = previtem.getId()
+                        self.finalizeResourceMerging(resource, previtem)
+                        
+                        # Add the original id under concatenated resources or
+                        # create a new one starting with the previous item
+                        if concatenatedResources.has_key(prev_id):
+                            concatenatedResources[prev_id].append(res_id)
+                        else:
+                            magic_id = self.generateId(resource, previtem)
+                            concatenatedResources[magic_id] = [prev_id, res_id]
+                            previtem._setId(magic_id)
+                        
                     else:
-                        magic_id = self.generateId(res_id, prev_id)
-                        self.concatenatedresources[magic_id] = [prev_id, res_id]
-                        previtem._setId(magic_id)
-                else:
+                        if resource.getCookable() or resource.getCacheable():
+                            magic_id = self.generateId(resource)
+                            concatenatedResources[magic_id] = [resource.getId()]
+                            resource._setId(magic_id)
+                        results.append(resource)
+                else: # No resources collated yet
+                
+                    # If cookable or cacheable, generate a magic id, change
+                    # the resource id to be this id, and record the old id in the
+                    # list of ids for this magic id under concatenated resources
                     if resource.getCookable() or resource.getCacheable():
-                        magic_id = self.generateId(resource.getId())
-                        self.concatenatedresources[magic_id] = [resource.getId()]
+                        magic_id = self.generateId(resource)
+                        concatenatedResources[magic_id] = [resource.getId()]
                         resource._setId(magic_id)
                     results.append(resource)
-            else:
-                if resource.getCookable() or resource.getCacheable():
-                    magic_id = self.generateId(resource.getId())
-                    self.concatenatedresources[magic_id] = [resource.getId()]
-                    resource._setId(magic_id)
-                results.append(resource)
-
-        resources = self.getResources()
-        for resource in resources:
-            self.concatenatedresources[resource.getId()] = [resource.getId()]
-        self.cookedresources = tuple(results)
+                    
+            # Get the raw list of resources and store these as well in
+            # concatenated resources
+            resources = self.getResources()
+            for resource in resources:
+                concatenatedResources[resource.getId()] = [resource.getId()]
+            
+            self.cookedResourcesByTheme[theme] = tuple(results)
 
     security.declarePrivate('evaluate')
     def evaluate(self, item, context):
@@ -520,9 +643,13 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         return None
 
     security.declarePrivate('getResourceContent')
-    def getResourceContent(self, item, context, original=False):
+    def getResourceContent(self, item, context, original=False, theme=None):
         """Fetch resource content for delivery."""
-        ids = self.concatenatedresources.get(item, None)
+        
+        if theme is None:
+            theme = self.getCurrentSkinName()
+
+        ids = self.concatenatedResourcesByTheme.get(theme, {}).get(item, None)
         resources = self.getResourcesDict()
         if ids is not None:
             ids = ids[:]
@@ -733,6 +860,52 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         if REQUEST:
             REQUEST.RESPONSE.redirect(REQUEST['HTTP_REFERER'])
 
+    security.declareProtected(permissions.ManagePortal, 'getBundlesForThemes')
+    def getBundlesForThemes(self):
+        """Get the mapping of theme names to lists of bundles
+        """
+        
+        mappings = {}
+        
+        registry = queryUtility(IRegistry)
+        if registry is not None:
+            mappings = registry.forInterface(IResourceRegistriesSettings, False).resourceBundlesForThemes or {}
+            mappings = dict(mappings) # clone as builtin dict, even if non-builtin dict
+        
+        portal_skins = getToolByName(self, 'portal_skins')
+        for theme in portal_skins.getSkinSelections():
+            if not theme in mappings:
+                mappings[theme] = ['default']
+        
+        return mappings
+        
+    security.declareProtected(permissions.ManagePortal, 'getBundlesForTheme')
+    def getBundlesForTheme(self, theme=None):
+        """Get the bundles for a particular theme (defaults to the current)
+        """
+        
+        if theme is None:
+            theme = self.getCurrentSkinName()
+        
+        return self.getBundlesForThemes().get(theme, ['default'])
+
+    security.declareProtected(permissions.ManagePortal, 'manage_saveBundlesForThemes')
+    def manage_saveBundlesForThemes(self, mappings={}, REQUEST=None):
+        """Save theme -> bundle mappings
+        """
+        registry = queryUtility(IRegistry)
+        settings = registry.forInterface(IResourceRegistriesSettings)
+        
+        m = {}
+        for k,v in mappings.items():
+            m[str(k)] = [str(x) for x in v if x]
+        settings.resourceBundlesForThemes = m
+        
+        self.cookResources()
+        
+        if REQUEST:
+            REQUEST.RESPONSE.redirect(REQUEST['HTTP_REFERER'])
+    
     #
     # Protected Methods
     #
@@ -740,21 +913,23 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
     security.declareProtected(permissions.ManagePortal, 'registerResource')
     def registerResource(self, id, expression='', enabled=True,
                          cookable=True, cacheable=True, conditionalcomment='',
-                         authenticated=False):
+                         authenticated=False, bundle='default'):
         """Register a resource."""
-        resource = Resource(id,
+        resource = self.resource_class(
+                            id,
                             expression=expression,
                             enabled=enabled,
                             cookable=cookable,
                             cacheable=cacheable,
                             conditionalcomment=conditionalcomment,
-                            authenticated=authenticated)
+                            authenticated=authenticated,
+                            bundle=bundle)
         self.storeResource(resource)
 
     security.declareProtected(permissions.ManagePortal, 'unregisterResource')
     def unregisterResource(self, id):
         """Unregister a registered resource."""
-        resources = [item for item in self.getResources()
+        resources = [item for item in self.resources
                      if item.getId() != id]
         self.resources = tuple(resources)
         self.cookResources()
@@ -762,7 +937,7 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
     security.declareProtected(permissions.ManagePortal, 'renameResource')
     def renameResource(self, old_id, new_id):
         """Change the id of a registered resource."""
-        self.validateId(new_id, self.getResources())
+        self.validateId(new_id, self.resources)
         resources = list(self.resources)
         for resource in resources:
             if resource.getId() == old_id:
@@ -774,7 +949,7 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
     security.declareProtected(permissions.ManagePortal, 'getResourceIds')
     def getResourceIds(self):
         """Return the ids of all resources."""
-        return tuple([x.getId() for x in self.getResources()])
+        return tuple([x.getId() for x in self.resources])
 
     security.declareProtected(permissions.ManagePortal, 'getResources')
     def getResources(self):
@@ -783,27 +958,44 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         For management screens.
         """
         result = []
-        for item in self.resources:
-            if isinstance(item, dict):
-                # BBB we used dicts before
-                item = item.copy()
-                item_id = item['id']
-                del item['id']
-                obj = self.resource_class(item_id, **item)
-                result.append(obj)
-            else:
-                result.append(item)
+        
+        for name, provider in getAdapters((self,), IResourceProvider):
+            for item in provider.getResources():
+                if isinstance(item, dict):
+                    # BBB we used dicts before
+                    item = item.copy()
+                    item_id = item['id']
+                    del item['id']
+                    obj = self.resource_class(item_id, **item)
+                    result.append(obj)
+                else:
+                    result.append(item)
         return tuple(result)
 
     security.declareProtected(permissions.ManagePortal, 'getCookedResources')
-    def getCookedResources(self):
+    def getCookedResources(self, theme=None):
         """Get the cooked resource data."""
         result = []
+        
+        if theme is None:
+            theme = self.getCurrentSkinName()
+        
+        # If we don't recognise the theme, pretend we're the default one
+        bundlesForThemes = self.getBundlesForThemes()
+
+        if self.cookedResourcesByTheme is _marker:
+            self._migrateCookedResouces()
+        
+        if theme not in bundlesForThemes or theme not in self.cookedResourcesByTheme:
+            portal_skins = getToolByName(self, 'portal_skins')
+            theme = portal_skins.getDefaultSkin()
+        
         if self.getDebugMode():
-            resources = [r.copy() for r in self.getResources() if r.getEnabled()]
-            result = [x for x in resources]
+            bundles = bundlesForThemes.get(theme, ['default'])
+            result = [r.copy() for r in self.getResources() \
+                            if r.getEnabled() and (not r.getBundle() or r.getBundle() in bundles)]
         else:
-            result = [x for x in self.cookedresources]
+            result = [x for x in self.cookedResourcesByTheme.get(theme, ())]
         return tuple(result)
 
     security.declareProtected(permissions.ManagePortal, 'moveResource')
@@ -814,7 +1006,7 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
             return
         elif position < 0:
             position = 0
-        resources = list(self.getResources())
+        resources = list(self.resources)
         resource = resources.pop(index)
         resources.insert(position, resource)
         self.resources = tuple(resources)
@@ -848,9 +1040,9 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         DEVEL_MODE[self.id] = bool(value)
 
     security.declareProtected(permissions.View, 'getEvaluatedResources')
-    def getEvaluatedResources(self, context):
+    def getEvaluatedResources(self, context, theme=None):
         """Return the filtered evaluated resources."""
-        results = self.getCookedResources()
+        results = self.getCookedResources(theme=theme)
         return [item for item in results if self.evaluate(item, context)]
 
     security.declareProtected(permissions.View, 'getInlineResource')
@@ -874,5 +1066,15 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         Should be overwritten by subclasses.
         """
         return 'text/plain'
+
+    security.declarePublic('getCurrentSkinName')
+    def getCurrentSkinName(self):
+        """Get the currently active skin name
+        """
+        
+        # For reasons of horridness, we can't use acquisition here
+        portal_url = getToolByName(getSite(), 'portal_url')
+        return portal_url.getPortalObject().getCurrentSkinName()
+        
 
 InitializeClass(BaseRegistryTool)

--- a/Products/ResourceRegistries/tools/CSSRegistry.py
+++ b/Products/ResourceRegistries/tools/CSSRegistry.py
@@ -149,8 +149,8 @@ class CSSRegistryTool(BaseRegistryTool):
     security.declarePrivate('storeResource')
     def storeResource(self, resource, skipCooking=False):
         """Store a resource."""
-        self.validateId(resource.getId(), self.getResources())
-        resources = list(self.getResources())
+        self.validateId(resource.getId(), self.resources)
+        resources = list(self.resources)
         if len(resources) and resources[-1].getId() == 'ploneCustom.css':
             # ploneCustom.css should be the last item
             resources.insert(-1, resource)
@@ -230,12 +230,12 @@ class CSSRegistryTool(BaseRegistryTool):
                              enabled=False, cookable=True, compression='safe',
                              cacheable=True, REQUEST=None,
                              conditionalcomment='', authenticated=False,
-                             applyPrefix=False):
+                             applyPrefix=False, bundle='default'):
         """Register a stylesheet from a TTW request."""
         self.registerStylesheet(id, expression, media, rel, title,
                                 rendering, enabled, cookable, compression,
                                 cacheable, conditionalcomment, authenticated,
-                                applyPrefix=applyPrefix)
+                                applyPrefix=applyPrefix, bundle=bundle)
         if REQUEST:
             REQUEST.RESPONSE.redirect(REQUEST['HTTP_REFERER'])
 
@@ -247,12 +247,13 @@ class CSSRegistryTool(BaseRegistryTool):
         """
         debugmode = REQUEST.get('debugmode', False)
         self.setDebugMode(debugmode)
-        records = REQUEST.get('stylesheets')
+        records = REQUEST.get('stylesheets', [])
         records.sort(lambda a, b: a.sort - b.sort)
         self.resources = ()
         stylesheets = []
         for r in records:
-            stylesheet = Stylesheet(r.get('id'),
+            stylesheet = self.resource_class(
+                                    r.get('id'),
                                     expression=r.get('expression', ''),
                                     media=r.get('media', 'screen'),
                                     rel=r.get('rel', 'stylesheet'),
@@ -264,7 +265,8 @@ class CSSRegistryTool(BaseRegistryTool):
                                     compression=r.get('compression', 'safe'),
                                     conditionalcomment=r.get('conditionalcomment',''),
                                     authenticated=r.get('authenticated', False),
-                                    applyPrefix=r.get('applyPrefix', False))
+                                    applyPrefix=r.get('applyPrefix', False),
+                                    bundle=r.get('bundle', 'default'))
             stylesheets.append(stylesheet)
         self.resources = tuple(stylesheets)
         self.cookResources()
@@ -288,13 +290,14 @@ class CSSRegistryTool(BaseRegistryTool):
                            enabled=1, cookable=True, compression='safe',
                            cacheable=True, conditionalcomment='',
                            authenticated=False, skipCooking=False,
-                           applyPrefix=False):
+                           applyPrefix=False, bundle='default'):
         """Register a stylesheet."""
         
         if not id:
             raise ValueError("id is required")
         
-        stylesheet = Stylesheet(id,
+        stylesheet = self.resource_class(
+                                id,
                                 expression=expression,
                                 media=media,
                                 rel=rel,
@@ -306,7 +309,8 @@ class CSSRegistryTool(BaseRegistryTool):
                                 cacheable=cacheable,
                                 conditionalcomment=conditionalcomment,
                                 authenticated=authenticated,
-                                applyPrefix=applyPrefix)
+                                applyPrefix=applyPrefix,
+                                bundle=bundle)
         self.storeResource(stylesheet, skipCooking=skipCooking)
 
     security.declareProtected(permissions.ManagePortal, 'updateStylesheet')
@@ -339,6 +343,8 @@ class CSSRegistryTool(BaseRegistryTool):
             stylesheet.setConditionalcomment(data['conditionalcomment'])
         if data.get('applyPrefix',None) is not None:
             stylesheet.setApplyPrefix(data['applyPrefix'])
+        if data.get('bundle', None) is not None:
+            stylesheet.setBundle(data['bundle'])
 
     security.declareProtected(permissions.ManagePortal, 'getRenderingOptions')
     def getRenderingOptions(self):

--- a/Products/ResourceRegistries/www/bundles.zpt
+++ b/Products/ResourceRegistries/www/bundles.zpt
@@ -1,0 +1,99 @@
+<div tal:replace="structure here/manage_page_header" />
+
+<style type="text/css">
+form {
+    margin-bottom: 3em;
+}
+
+fieldset label,fieldset input,fieldset  select {
+    font-size: 80%;
+    font-family: sans-serif;
+    float: left;
+}
+
+legend input {
+    float: none;
+}
+
+fieldset label {
+    width: 11em;
+    text-align: right;
+    padding: 0.2em 0.4em;
+    font-weight: bold;
+    clear: left;
+}
+
+
+fieldset {
+    margin: 0.2em;
+    border: 1px solid black;
+    margin-bottom: 0.5em;
+    padding-bottom: 0;
+    clear: both;
+}
+
+legend {
+    font-size: 90%;
+}
+
+.hiddenLabel {
+    display: block;
+    background: transparent;
+    background-image: none; /* */
+    border: none;
+    height: 1px;
+    overflow: hidden;
+    padding: 0;
+    margin: -1px 0 0 -1px;
+    width: 1px;
+}
+
+</style>
+
+<div tal:replace="structure here/manage_tabs" />
+
+    <p>
+        Resource bundles are collections of related resources. Every resource
+        can be associated with a bundle.
+    </p>
+    <p>
+        Bundles are managed globally, across all registries. They are
+        associated with themes (skins): when a particular theme is enabled,
+        all the active resources in the associated bundles will be used. If a
+        resource is not associated with a bundle, it will be considered
+        global, and hence used always.
+    </p>
+
+    <form action="manage_saveBundlesForThemes"
+          tal:attributes="action string:${context/absolute_url}/manage_saveBundlesForThemes"
+          tal:define="mappings context/getBundlesForThemes"
+          method="post">
+
+        <fieldset>
+              <legend>Bundles for themes</legend>
+              
+              <p>Choose which bundles are associated with which themes</p>
+
+              <div tal:repeat="theme context/aq_parent/portal_skins/getSkinSelections">
+                  <label tal:content="theme" />
+                  
+                  <textarea
+                    rows="5"
+                    style="margin-bottom: 10px"
+                    tal:define="m python:mappings.get(theme, [])"
+                    tal:attributes="name string:mappings.${theme}:record:lines"
+                    tal:content="python:'\n'.join(m)"
+                    />
+                  
+              </div>
+
+              <p style="clear:both">&nbsp;</p>
+              <div>
+                  <input type="submit" i18n:attributes="value" value="Save" />
+              </div>
+              <p style="clear:both">&nbsp;</p>
+
+        </fieldset>
+    </form>
+
+<div tal:replace="structure here/manage_page_footer" />

--- a/Products/ResourceRegistries/www/csscomposition.zpt
+++ b/Products/ResourceRegistries/www/csscomposition.zpt
@@ -11,41 +11,46 @@
 
 <p>Overview of which stylesheets are merged to create composite stylesheets.</p> 
 
-<ul tal:define="portal_url python:here.portal_url()">
-    <li tal:repeat="entry python:here.getCookedResources()">
-        <div>
-            <a href=""
-               tal:define="portalHref string:${portal_url}/portal_css/${entry/getId}"
-               tal:attributes="href python:test(entry.isExternalResource(),entry.getId(),portalHref)">
-                <b tal:content="entry/getId">ploneCustom.css</b>
-            </a>
-            <tal:block tal:condition="entry/getAuthenticated | nothing">
-            - <strong>restricted to authenticated users</strong>
-            </tal:block>
-            <tal:block tal:condition="not:entry/getAuthenticated">
-                <tal:block tal:condition="entry/getExpression | nothing">
-                - <span tal:replace="entry/getExpression" />
-                </tal:block>
-            </tal:block>
-            <tal:block tal:condition="entry/getConditionalcomment | nothing">
-            - <span tal:replace="string:&lt;!--[if ${entry/getConditionalcomment}]&gt;" />
-            </tal:block>
-        </div>
-        <ul tal:define="sheets here/concatenatedresources">
-          <tal:stylesheets tal:define="portal python:here.portal_url.getPortalObject();"
-                           tal:repeat="subentry python:sheets.get(entry.getId())">
-            <li tal:define="resourceExists python:entry.isExternalResource() or portal.restrictedTraverse(subentry, False) and True;"
-                tal:attributes="class python:test(resourceExists, nothing, 'notFound')">
-                <a href="" tal:define="subPortalHref string:${portal_url}/portal_css/${subentry}"
-                           tal:attributes="href python:test(entry.isExternalResource(),subentry,subPortalHref)"
-                           tal:content="subentry">
-                    plone.css
+<div tal:repeat="theme context/aq_parent/portal_skins/getSkinSelections">
+    
+    <h2 tal:content="theme" />
+
+    <ul tal:define="portal_url python:here.portal_url()">
+        <li tal:repeat="entry python:here.getCookedResources(theme)">
+            <div>
+                <a href=""
+                   tal:define="portalHref string:${portal_url}/portal_css/${entry/getId}"
+                   tal:attributes="href python:test(entry.isExternalResource(),entry.getId(),portalHref)">
+                    <b tal:content="entry/getId">ploneCustom.css</b>
                 </a>
-                <span tal:condition="not:resourceExists">(resource not found or not accessible)</span>
-            </li>
-          </tal:stylesheets>
-        </ul>
-    </li>
-</ul>
+                <tal:block tal:condition="entry/getAuthenticated | nothing">
+                - <strong>restricted to authenticated users</strong>
+                </tal:block>
+                <tal:block tal:condition="not:entry/getAuthenticated">
+                    <tal:block tal:condition="entry/getExpression | nothing">
+                    - <span tal:replace="entry/getExpression" />
+                    </tal:block>
+                </tal:block>
+                <tal:block tal:condition="entry/getConditionalcomment | nothing">
+                - <span tal:replace="string:&lt;!--[if ${entry/getConditionalcomment}]&gt;" />
+                </tal:block>
+            </div>
+            <ul tal:define="sheets python:context.concatenatedResourcesByTheme.get(theme, {})">
+              <tal:stylesheets tal:define="portal python:here.portal_url.getPortalObject();"
+                               tal:repeat="subentry python:sheets.get(entry.getId())">
+                <li tal:define="resourceExists python:entry.isExternalResource() or portal.restrictedTraverse(subentry, False) and True;"
+                    tal:attributes="class python:test(resourceExists, nothing, 'notFound')">
+                    <a href="" tal:define="subPortalHref string:${portal_url}/portal_css/${subentry}"
+                               tal:attributes="href python:test(entry.isExternalResource(),subentry,subPortalHref)"
+                               tal:content="subentry">
+                        plone.css
+                    </a>
+                    <span tal:condition="not:resourceExists">(resource not found or not accessible)</span>
+                </li>
+              </tal:stylesheets>
+            </ul>
+        </li>
+    </ul>
+</div>
 
 <div tal:replace="structure here/manage_page_footer" />

--- a/Products/ResourceRegistries/www/cssconfig.zpt
+++ b/Products/ResourceRegistries/www/cssconfig.zpt
@@ -276,6 +276,11 @@ ul {
         </div>
 
         <div class="stylesheetform">
+            
+            <label>Bundle</label>
+            <input type="text" name="stylesheets.bundle:records"
+                   tal:attributes="value stylesheet/getBundle|nothing" />
+            
             <label>CSS Media</label>
             <input type="text" name="stylesheets.media:records"
                    tal:attributes="value stylesheet/getMedia|nothing" />
@@ -327,10 +332,15 @@ ul {
           </div>
 
           <div>
+              <label>Bundle</label>
+              <input type="text" name="bundle" size="50" />
+          </div>
+          
+          <div>
               <label>Title</label>
               <input type="text" name="title" />
           </div>
-
+          
           <div>
               <label>Restrict to authenticated users? If yes, the condition will be ignored.</label>
               <input type="checkbox" name="authenticated" value="0" />

--- a/Products/ResourceRegistries/www/jscomposition.zpt
+++ b/Products/ResourceRegistries/www/jscomposition.zpt
@@ -11,41 +11,47 @@
 
 <p>Overview of which javascripts are merged to create composite javascripts.</p> 
 
-<ul tal:define="portal_url python:here.portal_url()">
-    <li tal:repeat="entry python:here.getCookedResources()">
-        <div>
-            <a href=""
-               tal:define="portalHref string:${portal_url}/portal_javascripts/${entry/getId}"
-               tal:attributes="href python:test(entry.isExternalResource(),entry.getId(),portalHref)">
-                <b tal:content="entry/getId">plone_ecmascript.js</b>
-            </a>
-            <tal:block tal:condition="entry/getAuthenticated | nothing">
-            - <strong>restricted to authenticated users</strong>
-            </tal:block>
-            <tal:block tal:condition="not:entry/getAuthenticated">
-                <tal:block tal:condition="entry/getExpression | nothing">
-                - <span tal:replace="entry/getExpression" />
-                </tal:block>
-            </tal:block>
-            <tal:block tal:condition="entry/getConditionalcomment | nothing">
-            - <span tal:replace="string:&lt;!--[if ${entry/getConditionalcomment}]&gt;" />
-            </tal:block>
-        </div>
-        <ul tal:define="scripts here/concatenatedresources">
-          <tal:scripts tal:define="portal python:here.portal_url.getPortalObject();"
-                       tal:repeat="subentry python:scripts.get(entry.getId())">
-            <li tal:define="resourceExists python:entry.isExternalResource() or portal.restrictedTraverse(subentry, False) and True;"
-                tal:attributes="class python:test(resourceExists, nothing, 'notFound')">
-                <a href="" tal:define="subPortalHref string:${portal_url}/portal_javascripts/${subentry}"
-                           tal:attributes="href python:test(entry.isExternalResource(),subentry,subPortalHref)"
-                           tal:content="subentry">
-                    plone.js
+<div tal:repeat="theme context/aq_parent/portal_skins/getSkinSelections">
+    
+    <h2 tal:content="theme" />
+
+    <ul tal:define="portal_url python:here.portal_url()">
+        <li tal:repeat="entry python:here.getCookedResources(theme)">
+            <div>
+                <a href=""
+                   tal:define="portalHref string:${portal_url}/portal_javascripts/${entry/getId}"
+                   tal:attributes="href python:test(entry.isExternalResource(),entry.getId(),portalHref)">
+                    <b tal:content="entry/getId">plone_ecmascript.js</b>
                 </a>
-                <span tal:condition="not:resourceExists">(resource not found or not accessible)</span>
-            </li>
-          </tal:scripts>
-        </ul>
-    </li>
-</ul>
+                <tal:block tal:condition="entry/getAuthenticated | nothing">
+                - <strong>restricted to authenticated users</strong>
+                </tal:block>
+                <tal:block tal:condition="not:entry/getAuthenticated">
+                    <tal:block tal:condition="entry/getExpression | nothing">
+                    - <span tal:replace="entry/getExpression" />
+                    </tal:block>
+                </tal:block>
+                <tal:block tal:condition="entry/getConditionalcomment | nothing">
+                - <span tal:replace="string:&lt;!--[if ${entry/getConditionalcomment}]&gt;" />
+                </tal:block>
+            </div>
+            <ul tal:define="scripts python:context.concatenatedResourcesByTheme.get(theme, {})">
+              <tal:scripts tal:define="portal python:here.portal_url.getPortalObject();"
+                           tal:repeat="subentry python:scripts.get(entry.getId())">
+                <li tal:define="resourceExists python:entry.isExternalResource() or portal.restrictedTraverse(subentry, False) and True;"
+                    tal:attributes="class python:test(resourceExists, nothing, 'notFound')">
+                    <a href="" tal:define="subPortalHref string:${portal_url}/portal_javascripts/${subentry}"
+                               tal:attributes="href python:test(entry.isExternalResource(),subentry,subPortalHref)"
+                               tal:content="subentry">
+                        plone.js
+                    </a>
+                    <span tal:condition="not:resourceExists">(resource not found or not accessible)</span>
+                </li>
+              </tal:scripts>
+            </ul>
+        </li>
+    </ul>
+
+</div>
 
 <div tal:replace="structure here/manage_page_footer" />

--- a/Products/ResourceRegistries/www/jsconfig.zpt
+++ b/Products/ResourceRegistries/www/jsconfig.zpt
@@ -246,6 +246,11 @@ legend {
         </div>
 
         <div class="scriptform">
+            
+            <label>Bundle</label>
+            <input type="text" name="scripts.bundle:records"
+                   tal:attributes="value script/getBundle|nothing" />
+            
             <label>Inline rendering</label>
             <input type="checkbox" name="scripts.inline:records:boolean"
                    tal:attributes="checked script/getInline;
@@ -286,6 +291,11 @@ legend {
             <label for="id">ID/URL</label>
             <input type="text" name="id" size="50" />
         </div>
+
+        <div>
+              <label>Bundle</label>
+              <input type="text" name="bundle" size="50" />
+          </div>
 
         <div>
             <label>Restrict to authenticated users? If yes, the condition will be ignored.</label>

--- a/Products/ResourceRegistries/www/ksscomposition.zpt
+++ b/Products/ResourceRegistries/www/ksscomposition.zpt
@@ -11,32 +11,38 @@
 
 <p>Overview of which kineticstylesheets are merged to create composite kineticstylesheets.</p> 
 
-<ul tal:define="portal_url python:here.portal_url()">
-    <li tal:repeat="entry python:here.getCookedResources()">
-        <div>
-            <a href="" tal:define="portalHref string:${portal_url}/portal_kss/${entry/getId}"
-                       tal:attributes="href python:test(entry.isExternalResource(),entry.getId(),portalHref)">
-                <b tal:content="entry/getId">ploneCustom.kss</b>
-            </a>
-            <tal:block tal:condition="entry/getExpression | nothing">
-            - <span tal:replace="entry/getExpression" />
-            </tal:block>
-        </div>
-        <ul tal:define="sheets here/concatenatedresources">
-          <tal:kineticstylesheets tal:define="portal python:here.portal_url.getPortalObject();"
-                           tal:repeat="subentry python:sheets.get(entry.getId())">
-            <li tal:define="resourceExists python:entry.isExternalResource() or portal.restrictedTraverse(subentry, False) and True;"
-                tal:attributes="class python:test(resourceExists, nothing, 'notFound')">
-                <a href=""  tal:define="subPortalHref string:${portal_url}/portal_kss/${subentry}"
-                            tal:attributes="href python:test(entry.isExternalResource(),subentry,subPortalHref)"
-                            tal:content="subentry">
-                    plone.kss
+<div tal:repeat="theme context/aq_parent/portal_skins/getSkinSelections">
+    
+    <h2 tal:content="theme" />
+
+    <ul tal:define="portal_url python:here.portal_url()">
+        <li tal:repeat="entry python:here.getCookedResources(theme)">
+            <div>
+                <a href="" tal:define="portalHref string:${portal_url}/portal_kss/${entry/getId}"
+                           tal:attributes="href python:test(entry.isExternalResource(),entry.getId(),portalHref)">
+                    <b tal:content="entry/getId">ploneCustom.kss</b>
                 </a>
-                <span tal:condition="not:resourceExists">(resource not found or not accessible)</span>
-            </li>
-          </tal:kineticstylesheets>
-        </ul>
-    </li>
-</ul>
+                <tal:block tal:condition="entry/getExpression | nothing">
+                - <span tal:replace="entry/getExpression" />
+                </tal:block>
+            </div>
+            <ul tal:define="sheets python:context.concatenatedResourcesByTheme.get(theme, {})">
+              <tal:kineticstylesheets tal:define="portal python:here.portal_url.getPortalObject();"
+                               tal:repeat="subentry python:sheets.get(entry.getId())">
+                <li tal:define="resourceExists python:entry.isExternalResource() or portal.restrictedTraverse(subentry, False) and True;"
+                    tal:attributes="class python:test(resourceExists, nothing, 'notFound')">
+                    <a href=""  tal:define="subPortalHref string:${portal_url}/portal_kss/${subentry}"
+                                tal:attributes="href python:test(entry.isExternalResource(),subentry,subPortalHref)"
+                                tal:content="subentry">
+                        plone.kss
+                    </a>
+                    <span tal:condition="not:resourceExists">(resource not found or not accessible)</span>
+                </li>
+              </tal:kineticstylesheets>
+            </ul>
+        </li>
+    </ul>
+
+</div>
 
 <div tal:replace="structure here/manage_page_footer" />

--- a/Products/ResourceRegistries/www/kssconfig.zpt
+++ b/Products/ResourceRegistries/www/kssconfig.zpt
@@ -241,6 +241,11 @@ legend {
         </div>
 
         <div class="kineticstylesheetform">
+            
+            <label>Bundle</label>
+            <input type="text" name="kineticstylesheets.bundle:records"
+                   tal:attributes="value kineticstylesheet/getBundle|nothing" />
+            
             <label>Compression type</label>
             <select name="kineticstylesheets.compression:records">
                 <option tal:define="options python:test(kineticstylesheet.isExternalResource(),here.getExternalCompressionOptions(),here.getCompressionOptions())"
@@ -272,6 +277,11 @@ legend {
           <div>
               <label for="id">ID/URL</label>
               <input type="text" name="id" size="50" />
+          </div>
+          
+          <div>
+              <label>Bundle</label>
+              <input type="text" name="bundle" size="50" />
           </div>
 
           <div>

--- a/README.txt
+++ b/README.txt
@@ -37,6 +37,13 @@ Linked stylesheets take some parameters:
 
 id -- The id mentioned above. the Zope id of the stylesheet to be used.
 
+bundle -- A resource bundle is like a tag, which can be applied to each
+resource. The default (implicit) bundle is called 'default', but other names
+can be used. Bundles are associated with themes (skins) on the 'Bundles' tab
+in the ZMI. Note that the same association applies to all resource registries,
+i.e. this is a global setting. Bundles act like a filter - only resources in
+the bundles listed for the current theme will be included.
+
 expression -- A CMF expression to be evaluated to check if the stylesheet
 should be included in output or not.
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '2.0.7dev'
+version = '2.1.1.dev0'
 
 setup(name='Products.ResourceRegistries',
       version=version,
@@ -42,5 +42,6 @@ setup(name='Products.ResourceRegistries',
         'DateTime',
         'ZODB3',
         'Zope2',
+        'plone.app.registry',
       ],
 )


### PR DESCRIPTION
This should fix https://dev.plone.org/ticket/12479

Currently (at least with Zope 2.13.10), if you happen to override a resource registered in a resource registry by uploading a resource as a OFS.Image.File into the custom folder under portal_skins, resource registries fail to merge the resource. This happens also, when you accidentally "customize" a registered "Filesystem File" from some skin folder and save it as such into the custom-folder (it becomes OFS.Image.File).

The failure is caused by BaseRegistryTool.getResourceContent not supporting OFS.Image.File, but calling its index_html-method, which 1) steals the response and 2) returns only an empty string for merging.
