### PR TITLE
Accept external registries that start with //

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,10 @@ Changelog
 2.2.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow users to add resources starting with '//', the proper way to link 
+  to external resources when serving over http and https. This makes it 
+  much easier to manage content on CDNs.
+  [eleddy]
 
 
 2.2.8 (2013-05-23)

--- a/Products/ResourceRegistries/tests/testBaseRegistry.py
+++ b/Products/ResourceRegistries/tests/testBaseRegistry.py
@@ -25,6 +25,7 @@ class BaseRegistryTestCase(unittest.TestCase):
                'bar.res/' : False, #expected to fail
                'foo/bar.res' : True, #perfectly fine
                'http://example.com/example.res' : True, #This should work now
+               '//example.com/example.res' : True, #CDN content
                }
         for id in ids:
             if ids[id]: #This shouldn't error

--- a/Products/ResourceRegistries/tools/BaseRegistry.py
+++ b/Products/ResourceRegistries/tools/BaseRegistry.py
@@ -95,8 +95,8 @@ class Resource(Persistent):
 
     def __init__(self, id, **kwargs):
         self._data = PersistentMapping()
-        extres = id.startswith('http://') or id.startswith('https://')
-        if id.startswith('/') or id.endswith('/') or ('//' in id and not extres):
+        extres = id.startswith('http://') or id.startswith('https://') or id.startswith('//') 
+        if not extres and (id.startswith('/') or id.endswith('/') or ('//' in id)):
             raise ValueError("Invalid Resource ID: %s" % id)
         self._data['id'] = id
         expression = kwargs.get('expression', '')

--- a/Products/ResourceRegistries/tools/CSSRegistry.py
+++ b/Products/ResourceRegistries/tools/CSSRegistry.py
@@ -17,6 +17,7 @@ from Products.ResourceRegistries.tools.BaseRegistry import Resource
 from Products.ResourceRegistries.utils import applyPrefix
 
 from packer import CSSPacker
+import logging
 
 
 class Stylesheet(Resource):
@@ -31,6 +32,10 @@ class Stylesheet(Resource):
         self._data['compression'] = kwargs.get('compression', 'safe')
         self._data['applyPrefix'] = kwargs.get('applyPrefix', False)
         if self.isExternal:
+            if id.startswith('//') and self._data['rendering'] != 'link':
+                # force a link. it doesn't make sense any other way
+                logging.warning(u'Stylesheets beginning with // must be rendered as links. Updated for you.')
+                self._data['rendering'] = 'link'
             if self._data['compression'] not in config.CSS_EXTERNAL_COMPRESSION_METHODS:
                 self._data['compression'] = 'none' #we have to assume none because of the default values
             if self._data['rendering'] not in config.CSS_EXTERNAL_RENDER_METHODS:


### PR DESCRIPTION
this is important for those who support both http and https. I don't know why this was blocked to begin with so a security review would be nice.
