### PR TITLE
Properly handle redirections

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 2.2.10 (unreleased)
 -------------------
 
+- Properly handle redirections from login view; resources used to be erased
+  on authentication redirect for POST action
+  [mihneasim]
+
 - Don't try to traverse to remote objects starting with '//', triggered 
   from plone.css
   [eleddy]

--- a/Products/ResourceRegistries/tools/CSSRegistry.py
+++ b/Products/ResourceRegistries/tools/CSSRegistry.py
@@ -254,6 +254,9 @@ class CSSRegistryTool(BaseRegistryTool):
 
         Updates the whole sequence. For editing and reordering.
         """
+        if REQUEST and not REQUEST.form:
+            REQUEST.RESPONSE.redirect(self.manage_workspace_url)
+            return
         debugmode = REQUEST.get('debugmode', False)
         self.setDebugMode(debugmode)
         records = REQUEST.get('stylesheets', [])

--- a/Products/ResourceRegistries/tools/JSRegistry.py
+++ b/Products/ResourceRegistries/tools/JSRegistry.py
@@ -158,6 +158,9 @@ class JSRegistryTool(BaseRegistryTool):
 
         Updates the whole sequence. For editing and reordering.
         """
+        if REQUEST and not REQUEST.form:
+            REQUEST.RESPONSE.redirect(self.manage_workspace_url)
+            return
         debugmode = REQUEST.get('debugmode', False)
         self.setDebugMode(debugmode)
         records = REQUEST.form.get('scripts', [])

--- a/Products/ResourceRegistries/tools/KSSRegistry.py
+++ b/Products/ResourceRegistries/tools/KSSRegistry.py
@@ -135,6 +135,9 @@ class KSSRegistryTool(BaseRegistryTool):
 
         Updates the whole sequence. For editing and reordering.
         """
+        if REQUEST and not REQUEST.form:
+            REQUEST.RESPONSE.redirect(self.manage_workspace_url)
+            return
         debugmode = REQUEST.get('debugmode', False)
         self.setDebugMode(debugmode)
         records = REQUEST.get('kineticstylesheets', [])


### PR DESCRIPTION
Redirections from login view can make the Manager lose all the data (when clicking save with session expired and returning from login) and get stuck in redirect loop.
This patch fixes this behaviour.
