### PR TITLE
Skip data URIs when making URLs absolute

### DIFF
--- a/Products/ResourceRegistries/tests/testAbsolutePrefix.py
+++ b/Products/ResourceRegistries/tests/testAbsolutePrefix.py
@@ -27,6 +27,10 @@ table {
 table p {
     background: url("http://example.org/absolute.jpg") repeat-x;
 }
+
+li {
+    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==");
+}
 """
     
     def test_simple_prefix(self):
@@ -51,6 +55,10 @@ table {
 
 table p {
     background: url("http://example.org/absolute.jpg") repeat-x;
+}
+
+li {
+    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==");
 }
 """, applyPrefix(self.cssSource, '/prefix'))
 
@@ -77,6 +85,10 @@ table {
 table p {
     background: url("http://example.org/absolute.jpg") repeat-x;
 }
+
+li {
+    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==");
+}
 """, applyPrefix(self.cssSource, '/prefix/'))
 
     def test_deep_prefix(self):
@@ -101,6 +113,10 @@ table {
 
 table p {
     background: url("http://example.org/absolute.jpg") repeat-x;
+}
+
+li {
+    background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==");
 }
 """, applyPrefix(self.cssSource, '/some/prefix'))
 

--- a/Products/ResourceRegistries/utils.py
+++ b/Products/ResourceRegistries/utils.py
@@ -1,7 +1,7 @@
 import re
 import os.path
 
-URL_MATCH = re.compile(r'''(url\s*\(\s*['"]?)([^'")]+)(['"]?\s*\))''', re.I | re.S)
+URL_MATCH = re.compile(r'''(url\s*\(\s*['"]?)(?!data:)([^'")]+)(['"]?\s*\))''', re.I | re.S)
 
 def makeAbsolute(path, prefix):
     """Make a url into an absolute URL by applying the given prefix


### PR DESCRIPTION
Currently, applyPrefix will convert URIs such as
url(data:image/svg+xml;base64,PD94bWwgdmVyc2lv) to absolute urls. This
patch uses (?!data:) to fail the RegEx match where the URI starts with
"data:"
