### PR TITLE
handle theme names containing a `.` correctly.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changelog
   http://stackoverflow.com/questions/9664282
   [thet]
 
+- bugfix: Handle theme names containing a `.` properly in ``manage_bundlesForm``
+  [fRiSi]
+
 - bugfix: do not convert URIs such as
   url(data:image/svg+xml;base64,PD94bWwgdmVyc2lv) to absolute urls
   see https://github.com/plone/Products.ResourceRegistries/pull/16

--- a/Products/ResourceRegistries/tools/BaseRegistry.py
+++ b/Products/ResourceRegistries/tools/BaseRegistry.py
@@ -95,7 +95,7 @@ class Resource(Persistent):
 
     def __init__(self, id, **kwargs):
         self._data = PersistentMapping()
-        extres = id.startswith('http://') or id.startswith('https://') or id.startswith('//') 
+        extres = id.startswith('http://') or id.startswith('https://') or id.startswith('//')
         if not extres and (id.startswith('/') or id.endswith('/') or ('//' in id)):
             raise ValueError("Invalid Resource ID: %s" % id)
         self._data['id'] = id
@@ -664,7 +664,7 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         default_charset = 'utf-8'
 
         for id in ids:
-            # skip external resources that look like //netdna.bootstrapcdn.com/etc... 
+            # skip external resources that look like //netdna.bootstrapcdn.com/etc...
             if id[0:2] == '//':
                 continue
             try:
@@ -905,7 +905,7 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
 
         m = {}
         for k,v in mappings.items():
-            m[str(k)] = [str(x) for x in v if x]
+            m[str(k).replace('___', '.')] = [str(x) for x in v if x]
         settings.resourceBundlesForThemes = m
 
         self.cookResources()

--- a/Products/ResourceRegistries/www/bundles.zpt
+++ b/Products/ResourceRegistries/www/bundles.zpt
@@ -71,20 +71,21 @@ legend {
 
         <fieldset>
               <legend>Bundles for themes</legend>
-              
+
               <p>Choose which bundles are associated with which themes</p>
 
               <div tal:repeat="theme context/aq_parent/portal_skins/getSkinSelections">
                   <label tal:content="theme" />
-                  
+
                   <textarea
                     rows="5"
                     style="margin-bottom: 10px"
-                    tal:define="m python:mappings.get(theme, [])"
+                    tal:define="m python:mappings.get(theme, []);
+                                themename python: theme.replace('.', '___')"
                     tal:attributes="name string:mappings.${theme}:record:lines"
                     tal:content="python:'\n'.join(m)"
                     />
-                  
+
               </div>
 
               <p style="clear:both">&nbsp;</p>


### PR DESCRIPTION
zpublisher puts them into another namespace so manage_saveBundlesFortheme won't find theme.

eg ``REQUEST.form`` is::

  {'mappings.my': {'theme': ['jquery', 'mytheme']}, 'mappings': {'Plone Classic Theme': ['jquery', 'default'], 'Plone Default': ['jquery', 'default'], 'Sunburst Theme': ['jquery', 'default']}}

instead of::

  {'mappings': {'my.theme': ['jquery', 'mytheme'], 'Plone Classic Theme': ['jquery', 'default'], 'Plone Default': ['jquery', 'default'], 'Sunburst Theme': ['jquery', 'default']}}

we work around this by replacing dots with `___` in the form handling.