### PR TITLE
Removed assertion for response status 200 for inline resources.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,14 @@ Changelog
 2.2.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Removed assertion for response status 200 for inline resources.
+  If after inlining a ``++resource++`` item the response status was not in the
+  200 range, the assertion would fail, leading to the html being returned
+  with a wrong mimetype showing raw html and an error while rendering
+  ``plone.resourceregistries``.
+  Changed it into a condition instead: only restore original headers when
+  the status is in 200.
+  [maurits]
 
 
 2.2.12 (2016-06-21)

--- a/Products/ResourceRegistries/tools/BaseRegistry.py
+++ b/Products/ResourceRegistries/tools/BaseRegistry.py
@@ -795,7 +795,8 @@ class BaseRegistryTool(UniqueObject, SimpleItem, PropertyManager, Cacheable):
         # Now restore the headers and for safety, check that we
         # have a 20x response. If not, we have a problem and
         # some browser would hang indefinitely at this point.
-        assert int(self.REQUEST.RESPONSE.getStatus()) / 100 == 2
+        if int(self.REQUEST.RESPONSE.getStatus()) / 100 != 2:
+            return
         self.REQUEST.environ['HTTP_IF_MODIFIED_SINCE'] = if_modified
         self.REQUEST.RESPONSE.headers = original_response_headers
 


### PR DESCRIPTION
If after inlining a ``++resource++`` item the response status was not in the 200 range, the assertion would fail, leading to the html being returned with a wrong mimetype showing raw html and an error while rendering ``plone.resourceregistries``.

Changed it into a condition instead: only restore original headers when the status is in 200.

A customer saw this on the `NotFound` page. I don't know how to trigger it exactly, but you can see the effect like this:

- Edit `tools/BaseRegistry.py` and change the assertion to `assert False` so it always fails.
- Go to `portal_javascripts` and change one of the `++resource++` files to inline.
- Visit any page and you should see raw html, with in the head section a line `error while rendering plone.resourceregistries`.

I guess it could be triggered if you have a resource that is loaded for anonymous users but that itself raises a 404 or an Unauthorized.