### PR TITLE
Change imports in __init__.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,15 +1,8 @@
 Changelog
 =========
 
-.. You should *NOT* be adding new change log entries to this file.
-   You should create a file in the news directory instead.
-   For helpful instructions, please see:
-   https://github.com/plone/plone.releaser/blob/master/ADD-A-NEWS-ITEM.rst
 
-.. towncrier release notes start
-
-
-3.0.8 (2020-07-28)
+3.0.8 (unreleased)
 ------------------
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,15 @@ Changelog
 .. towncrier release notes start
 
 
+3.0.8 (2020-07-28)
+------------------
+
+Bug fixes:
+
+- Fix imports 
+  [1letter]
+
+
 3.0.7 (2018-04-08)
 ------------------
 

--- a/Products/ResourceRegistries/__init__.py
+++ b/Products/ResourceRegistries/__init__.py
@@ -1,5 +1,5 @@
 from Products.CMFCore.utils import ToolInit
-from Products.ResourceRegistries import config
+from Products.ResourceRegistries.config import PROJECTNAME
 from Products.ResourceRegistries.tools import CSSRegistry
 from Products.ResourceRegistries.tools import JSRegistry
 from Products.ResourceRegistries.tools import KSSRegistry
@@ -14,7 +14,7 @@ def initialize(context):
     )
 
     ToolInit(
-        config.PROJECTNAME + ' Tool',
+        PROJECTNAME + ' Tool',
         tools = TOOLS,
         icon = 'tool.gif',
     ).initialize(context)


### PR DESCRIPTION
an error happens during migration to Plone5
the statement: __import__('.'.join(parts_copy)) raise an error
it happens in GenericSetup/utils.py Line 109